### PR TITLE
Convert items to links.

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -71,6 +71,8 @@ block content
           h2.header ALL THE MEDIUMS.
           p.description
             ul
-              li Twitter (href="https://twitter.com/DecentralizeAll")
-              li Google+ (href="https://plus.google.com/u/0/112799215242542928928/posts")
+              li
+                a(href="https://twitter.com/DecentralizeAll") Twitter
+              li
+                a(href="https://plus.google.com/u/0/112799215242542928928/posts") Google+
         a.ui.bottom.attached.button(href="/contact") Email Us &raquo;


### PR DESCRIPTION
Hey James!  You had the right idea.  Here's a patch to tidy it up.  Notice that the attributes need to go directly after the tag name.
